### PR TITLE
[fix] 뒤로가기 버튼을 프로필 목록 페이지 이동으로 수정

### DIFF
--- a/src/pageContainer/ProfilePages/ProfileDetailPage/index.tsx
+++ b/src/pageContainer/ProfilePages/ProfileDetailPage/index.tsx
@@ -77,7 +77,7 @@ export default function ProfileDetailPage() {
       <ArrowBtn
         width="2.25rem"
         height="2.25rem"
-        onClick={() => router.back()}
+        onClick={() => router.push(`/profile/list`)}
       />
 
       <h1 className={S.Name}>{profile.name}</h1>


### PR DESCRIPTION
## 개요 💡

>뒤로가기 버튼을 프로필 목록 페이지 이동으로 수정하였습니다.

## 화면
https://github.com/user-attachments/assets/ea3cab31-57e1-4636-ab25-809a9bde981a

