### PR TITLE
[fix] Pretendard 웹폰트 링크 재추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,6 +21,14 @@ const RootLayout = ({
 }>) => {
   return (
     <html lang="ko">
+      <head>
+        <link
+          rel="stylesheet"
+          as="style"
+          crossOrigin=""
+          href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.6/dist/web/variable/pretendardvariable-dynamic-subset.css"
+        />
+      </head>
       <body className={themeClass}>
         <Provider>
           <Header />


### PR DESCRIPTION
## 개요 💡

> 실수로 삭제된 Pretendard 웹폰트 링크를 `<head>`에 다시 추가했습니다.
