### PR TITLE
[feat] 글자 수 제한 알림 및 요청 데이터 trim 처리

### DIFF
--- a/src/pageContainer/WritePage/index.tsx
+++ b/src/pageContainer/WritePage/index.tsx
@@ -124,6 +124,8 @@ const WritePage = () => {
               const newContent = e.target.value;
               if (newContent.length <= MAX_CONTENT_LENGTH) {
                 setContent(newContent);
+              } else {
+                toast.warn('2400자를 초과했습니다.');
               }
               handleResizeHeight(e);
             }}

--- a/src/pageContainer/WritePage/index.tsx
+++ b/src/pageContainer/WritePage/index.tsx
@@ -60,8 +60,8 @@ const WritePage = () => {
     mutationFn: () =>
       put('/profile', {
         wanted: selectedClubs,
-        major,
-        content,
+        major: major.trim(),
+        content: content.trim(),
       }),
     onSuccess: () => {
       if (myProfile && myProfile.studentId && myProfile.name) {


### PR DESCRIPTION
## 개요 💡

2400자 이상 작성 시도시 toast가 뜨도록하고, put 요청을 보낼때 trim()을 사용해서 양쪽 여백이 사라지도록 했습니다

## 작업내용 ⌨️

- 2400자 초과 작성시 toast 알림
- 요청 데이터에 trim()을 적용시켜서 보내도록 변경