### PR TITLE
[feat] 새로고침, 브라우저 닫기 이탈 방지 처리

### DIFF
--- a/src/pageContainer/WritePage/index.tsx
+++ b/src/pageContainer/WritePage/index.tsx
@@ -56,6 +56,21 @@ const WritePage = () => {
     }
   }, [myProfile]);
 
+  useEffect(() => {
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+      return '작성하던 내용이 모두 사라집니다. 계속하시겠습니까?';
+    };
+
+    if (window !== undefined)
+      window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
   const { mutate } = useMutation({
     mutationFn: () =>
       put('/profile', {


### PR DESCRIPTION
## 개요 💡

사용자가 페이지를 이탈(새로고침, 브라우저 닫기)하는 것을 방지했습니다.

## 작업내용 ⌨️

- window 객체에 이벤트를 추가 해 사용자가 새로고침 또는 브라우저를 닫으려고 하면 확인창을 띄움

## 관련 issue 🤯

Link 태그와 같이 router를 사용하여 이동(ex 헤더) 할 때는 확인창이 뜨고있지 않습니다. 현재 해당 문제 해결방법 조사중입니다.
