### PR TITLE
[fix] Toastify 메시지 통일

### DIFF
--- a/src/pageContainer/ClubsPage/index.tsx
+++ b/src/pageContainer/ClubsPage/index.tsx
@@ -27,7 +27,7 @@ const ClubsPage = () => {
   if (isLoading) return <Loading />;
 
   if (error) {
-    toast.error('정보 불러오기 중 오류 발생.');
+    toast.error('정보 불러오기 중 오류가 발생했습니다.');
     console.error(error);
   }
 

--- a/src/pageContainer/PasswordPage/index.tsx
+++ b/src/pageContainer/PasswordPage/index.tsx
@@ -78,8 +78,8 @@ const PasswordPage = () => {
 
       setIsLogged(true);
 
-      toast.success('비밀번호 재설정에 성공했습니다!');
-      toast.success('로그인에 성공했습니다');
+      toast.success('비밀번호 재설정에 성공했습니다.');
+      toast.success('로그인에 성공했습니다.');
       router.push('/signin');
     } catch (error: any) {
       toast.error('비밀번호 재설정에 실패했습니다.');
@@ -101,12 +101,12 @@ const PasswordPage = () => {
 
     try {
       await axiosInstance.post('/auth/send-email', email);
-      toast.success('이메일 전송이 완료되었습니다!');
-      toast.info('메일이 안왔다면 스팸 메일함을 확인해주세요');
+      toast.success('이메일 전송이 완료되었습니다.');
+      toast.info('메일이 보이지 않는다면 스팸함을 확인해주세요.');
       setAuthStack(0);
       setAuthIsOpen(true);
     } catch (error) {
-      toast.error('이메일 전송이 실패했습니다');
+      toast.error('이메일 전송이 실패했습니다.');
       console.error(error);
     }
   };
@@ -127,8 +127,9 @@ const PasswordPage = () => {
     } catch (error) {
       setAuthStack((e) => e + 1);
       if (authStack === 4) {
-        toast.info('이메일 인증에 5회 실패했습니다');
-        toast.info('모든 인증이 5분동안 수행되지 않습니다');
+        toast.info(
+          '이메일 인증에 5회 실패했습니다. 5분 후 다시 시도해 주세요.'
+        );
         countBlockTime(setBlockTime);
         setAuthStack((e) => e + 1);
       } else {
@@ -174,7 +175,7 @@ const PasswordPage = () => {
 
   useEffect(() => {
     if (authStack > 4) {
-      toast.info('email 인증코드를 다시 받아주세요');
+      toast.info('이메일 인증코드를 다시 받아주세요.');
       return;
     }
 
@@ -235,7 +236,7 @@ const PasswordPage = () => {
                       setAuthBtn(true);
                       return true;
                     }
-                    return '이메일 형식에 맞지 않습니다';
+                    return '이메일 형식이 올바르지 않습니다.';
                   },
                 })}
               />
@@ -285,7 +286,7 @@ const PasswordPage = () => {
                         return undefined;
                       }
                       if (String(value).length > 6) {
-                        return '6글자 아래로 입력해 주세요';
+                        return '6글자 이하로 입력해 주세요.';
                       }
                       return (
                         /^\d+$/.test(String(value)) || '숫자만 입력해주세요.'
@@ -370,7 +371,7 @@ const PasswordPage = () => {
                   if (watch('newpassword') === value) {
                     return true;
                   }
-                  return '비밀번호가 일치하지 않습니다';
+                  return '비밀번호가 일치하지 않습니다.';
                 },
               })}
             />

--- a/src/pageContainer/ProfilePages/ProfileDetailPage/index.tsx
+++ b/src/pageContainer/ProfilePages/ProfileDetailPage/index.tsx
@@ -60,11 +60,8 @@ export default function ProfileDetailPage() {
   if (isLoading) return <Loading />;
 
   if (profileError || myProfileError) {
-    toast.error('정보 불러오기 중 오류 발생.');
-    console.error(
-      '프로필 불러오는 중 오류 발생:',
-      profileError || myProfileError
-    );
+    toast.error('프로필 정보를 찾을 수 없습니다.');
+    console.error(profileError || myProfileError);
   }
 
   if (!profile && isMyProfile) return <EmptyProfile />;

--- a/src/pageContainer/ProfilePages/ProfileListPage/index.tsx
+++ b/src/pageContainer/ProfilePages/ProfileListPage/index.tsx
@@ -38,8 +38,8 @@ export default function ProfileListPage() {
   if (isLoading) return <Loading />;
 
   if (error) {
-    toast.error('정보 불러오기 중 오류 발생.');
-    console.error('프로필 목록 불러오는 중 오류 발생: ', error);
+    toast.error('정보 불러오기 중 오류가 발생했습니다.');
+    console.error(error);
   }
 
   const toggleClub = (club: string) => {

--- a/src/pageContainer/SignUpPage/stepOne/index.tsx
+++ b/src/pageContainer/SignUpPage/stepOne/index.tsx
@@ -110,9 +110,9 @@ const SignUpOnePage = ({
       if (response) {
         setError('email', {
           type: 'server',
-          message: '이미 존재하는 이메일입니다',
+          message: '이미 존재하는 이메일입니다.',
         });
-        toast.error('이미 존재하는 이메일입니다');
+        toast.error('이미 존재하는 이메일입니다.');
       } else {
         updateAuthStack(0);
         localStorage.removeItem('auth_stack_signup');
@@ -139,12 +139,12 @@ const SignUpOnePage = ({
 
     try {
       await axiosInstance.post('/auth/send-email', email);
-      toast.success('이메일 전송이 완료되었습니다!');
-      toast.info('메일이 안왔다면 스팸 메일함을 확인해주세요');
+      toast.success('이메일 전송이 완료되었습니다.');
+      toast.info('메일이 보이지 않는다면 스팸함을 확인해주세요.');
       updateAuthStack(0);
       setAuthIsOpen(true);
     } catch (error) {
-      toast.error('이메일 전송이 실패했습니다');
+      toast.error('이메일 전송이 실패했습니다.');
       console.error(error);
     }
   };
@@ -169,8 +169,9 @@ const SignUpOnePage = ({
       updateAuthStack(newStack);
 
       if (newStack === 5) {
-        toast.info('이메일 인증에 5회 실패했습니다');
-        toast.info('모든 인증이 5분동안 수행되지 않습니다');
+        toast.info(
+          '이메일 인증에 5회 실패했습니다. 5분 후 다시 시도해 주세요.'
+        );
         countBlockTime(setBlockTime);
       } else {
         toast.error('이메일 인증에 실패했습니다.');
@@ -217,7 +218,7 @@ const SignUpOnePage = ({
 
   useEffect(() => {
     if (authStack > 4) {
-      toast.info('email 인증코드를 다시 받아주세요');
+      toast.info('이메일 인증코드를 다시 받아주세요.');
       return;
     }
 
@@ -298,7 +299,7 @@ const SignUpOnePage = ({
                     ) {
                       return true;
                     }
-                    return '이메일 형식에 맞지 않습니다';
+                    return '이메일 형식이 올바르지 않습니다.';
                   },
                 })}
               />
@@ -348,7 +349,7 @@ const SignUpOnePage = ({
                         return undefined;
                       }
                       if (String(value).length > 6) {
-                        return '6글자 아래로 입력해 주세요';
+                        return '6글자 이하로 입력해 주세요.';
                       }
                       return (
                         /^\d+$/.test(String(value)) || '숫자만 입력해주세요.'
@@ -433,7 +434,7 @@ const SignUpOnePage = ({
                   if (watch('password') === value) {
                     return true;
                   }
-                  return '비밀번호가 일치하지 않습니다';
+                  return '비밀번호가 일치하지 않습니다.';
                 },
               })}
             />

--- a/src/pageContainer/SignUpPage/stepOne/index.tsx
+++ b/src/pageContainer/SignUpPage/stepOne/index.tsx
@@ -120,11 +120,7 @@ const SignUpOnePage = ({
         onNext();
       }
     } catch (error: any) {
-      if (error.response?.state === 404 && error.response?.state === 503) {
-        toast.error('에러가 발생했습니다');
-      } else {
-        toast.error('서버통신중 에러가 발생했습니다');
-      }
+      toast.error('문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
     }
   };
 

--- a/src/pageContainer/SignUpPage/stepTwo/index.tsx
+++ b/src/pageContainer/SignUpPage/stepTwo/index.tsx
@@ -59,7 +59,7 @@ const SignUpTwoPage = ({ formData, onPrev }: SignUpTwoPageProps) => {
 
       setIsLogged(true);
 
-      toast.success('회원가입에 성공했습니다');
+      toast.success('회원가입에 성공했습니다.');
       router.push('/');
     } catch (error) {
       if (error instanceof AxiosError) {
@@ -80,7 +80,7 @@ const SignUpTwoPage = ({ formData, onPrev }: SignUpTwoPageProps) => {
   };
 
   const GoPrev = () => {
-    if (confirm('현재 변경사항이 저장되지 않았습니다. 계속하시겠습니까')) {
+    if (confirm('현재 변경사항이 저장되지 않았습니다. 계속하시겠습니까?')) {
       onPrev();
     }
   };
@@ -102,7 +102,7 @@ const SignUpTwoPage = ({ formData, onPrev }: SignUpTwoPageProps) => {
             onClick={() => handleFocus('name')}
           >
             <input
-              placeholder="이름을 입력해주세요"
+              placeholder="이름을 입력해주세요."
               className={S.InputBox}
               onClick={() => ClearError()}
               {...register('name', {

--- a/src/pageContainer/SignUpPage/stepTwo/index.tsx
+++ b/src/pageContainer/SignUpPage/stepTwo/index.tsx
@@ -80,7 +80,7 @@ const SignUpTwoPage = ({ formData, onPrev }: SignUpTwoPageProps) => {
   };
 
   const GoPrev = () => {
-    if (confirm('현재 변경사항이 저장되지 않았습니다. 계속하시겠습니까?')) {
+    if (confirm('작성하던 내용이 모두 사라집니다. 계속하시겠습니까?')) {
       onPrev();
     }
   };

--- a/src/pageContainer/WritePage/index.tsx
+++ b/src/pageContainer/WritePage/index.tsx
@@ -126,15 +126,15 @@ const WritePage = () => {
       }
     },
     onError: () => {
-      toast.error('오류가 발생했습니다.');
+      toast.error('문제가 발생했습니다. 잠시 후 다시 시도해 주세요.');
     },
   });
 
   if (myProfileLoading) return <Loading />;
 
   if (myProfileError) {
-    toast.error('정보 불러오기 중 오류 발생.');
-    console.error('자기소개서 내용을 불러오는 중 오류 발생: ', myProfileError);
+    toast.error('프로필 정보를 찾을 수 없습니다.');
+    console.error(myProfileError);
   }
 
   return (


### PR DESCRIPTION
## 개요 💡

> Toastify 메시지를 디자인과 통일시켰습니다.

## 작업내용 ⌨️

- Toastify 메시지 통일
- `console.error`의 출력 형식을 `console.error(error)`와 같은 방식으로 일관성 있게 수정했습니다.

## 관련 issue 🤯
`error.response?.state === 404 && error.response?.state === 503` 조건이 잘못되어 제거했고, 에러 메시지를 하나로 통일하여 사용자 안내를 명확하게 개선했습니다.