### PR TITLE
[fix] 이메일 인증 관련 로직

### DIFF
--- a/src/pageContainer/PasswordPage/index.tsx
+++ b/src/pageContainer/PasswordPage/index.tsx
@@ -81,7 +81,7 @@ const PasswordPage = () => {
 
       toast.success('비밀번호 재설정에 성공했습니다.');
       toast.success('로그인에 성공했습니다.');
-      router.push('/signin');
+      router.push('/');
     } catch (error: any) {
       toast.error('비밀번호 재설정에 실패했습니다.');
     }

--- a/src/pageContainer/PasswordPage/index.tsx
+++ b/src/pageContainer/PasswordPage/index.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks';
 import { axiosInstance } from '@/libs';
 import { LoginResponse } from '@/types';
 
+import { useMutation } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { FieldErrors, useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
@@ -92,23 +93,29 @@ const PasswordPage = () => {
     console.error(errors);
   };
 
-  const EmailAuth = async () => {
-    const email = { email: watch('email') };
-
-    if (email.email?.length === 6) {
-      email.email = email.email + '@gsm.hs.kr';
-    }
-
-    try {
-      await axiosInstance.post('/auth/send-email', email);
+  const { mutate, isPending } = useMutation({
+    mutationFn: async (email: string) => {
+      let sendEmail = email;
+      if (sendEmail?.length === 6) {
+        sendEmail = sendEmail + '@gsm.hs.kr';
+      }
+      await axiosInstance.post('/auth/send-email', { email: sendEmail });
+    },
+    onSuccess: () => {
       toast.success('이메일 전송이 완료되었습니다.');
       toast.info('메일이 보이지 않는다면 스팸함을 확인해주세요.');
       setAuthStack(0);
       setAuthIsOpen(true);
-    } catch (error) {
+    },
+    onError: (error) => {
       toast.error('이메일 전송이 실패했습니다.');
       console.error(error);
-    }
+    },
+  });
+
+  const EmailAuth = () => {
+    const email = watch('email');
+    mutate(email);
   };
 
   const checkAuthCode = async (authCode: number) => {
@@ -244,12 +251,14 @@ const PasswordPage = () => {
             </div>
             <div
               className={
-                authBtn && !emailAuth && !isBlock
+                authBtn && !emailAuth && !isBlock && !isPending
                   ? S.AuthButton
                   : S.BlockAuthButton
               }
               onClick={
-                authBtn && !emailAuth && !isBlock ? EmailAuth : undefined
+                !isPending && authBtn && !emailAuth && !isBlock
+                  ? EmailAuth
+                  : undefined
               }
             >
               인증

--- a/src/pageContainer/SignInPage/index.tsx
+++ b/src/pageContainer/SignInPage/index.tsx
@@ -47,7 +47,7 @@ const SignInPage = () => {
         '/auth/login',
         loginData
       );
-      return response.data;
+      return response as unknown as LoginResponse;
     },
     onSuccess: (response) => {
       document.cookie = `accessToken=${response.accessToken}; path=/;`;

--- a/src/pageContainer/SignUpPage/index.tsx
+++ b/src/pageContainer/SignUpPage/index.tsx
@@ -10,7 +10,7 @@ export default function SignUpPage() {
   const [formData, setFormData] = useState({
     email: '',
     password: '',
-    authCode: 0,
+    authCode: '',
   });
 
   const [authIsOpen, setAuthIsOpen] = useState<boolean>(false);

--- a/src/pageContainer/SignUpPage/stepOne/index.tsx
+++ b/src/pageContainer/SignUpPage/stepOne/index.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { CloseEyes, ImiLogo, OpenEyes } from '@/asset';
 import { axiosInstance } from '@/libs';
 
+import { useMutation } from '@tanstack/react-query';
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { FieldErrors, useForm } from 'react-hook-form';
 import { toast } from 'react-toastify';
@@ -130,24 +131,25 @@ const SignUpOnePage = ({
     console.error(errors);
   };
 
-  const EmailAuth = async () => {
-    const email = { email: watch('email') };
-
-    if (email.email.length === 6) {
-      email.email = email.email + '@gsm.hs.kr';
-    }
-
-    try {
-      await axiosInstance.post('/auth/send-email', email);
+  const { mutate, isPending } = useMutation({
+    mutationFn: async (email: string) => {
+      let sendEmail = email;
+      if (sendEmail?.length === 6) {
+        sendEmail = sendEmail + '@gsm.hs.kr';
+      }
+      await axiosInstance.post('/auth/send-email', { email: sendEmail });
+    },
+    onSuccess: () => {
       toast.success('이메일 전송이 완료되었습니다.');
       toast.info('메일이 보이지 않는다면 스팸함을 확인해주세요.');
       updateAuthStack(0);
       setAuthIsOpen(true);
-    } catch (error) {
+    },
+    onError: (error) => {
       toast.error('이메일 전송이 실패했습니다.');
       console.error(error);
-    }
-  };
+    },
+  });
 
   const checkAuthCode = async (authCode: number) => {
     const email = { email: watch('email') };
@@ -313,12 +315,14 @@ const SignUpOnePage = ({
             </div>
             <div
               className={
-                authBtn && !emailAuth && !isBlock
+                authBtn && !emailAuth && !isBlock && !isPending
                   ? S.AuthButton
                   : S.BlockAuthButton
               }
               onClick={
-                authBtn && !emailAuth && !isBlock ? EmailAuth : undefined
+                authBtn && !emailAuth && !isBlock && !isPending
+                  ? () => mutate(watch('email'))
+                  : undefined
               }
             >
               인증

--- a/src/pageContainer/SignUpPage/stepOne/index.tsx
+++ b/src/pageContainer/SignUpPage/stepOne/index.tsx
@@ -261,6 +261,12 @@ const SignUpOnePage = ({
     }
   }, [emailValue]);
 
+  useEffect(() => {
+    if ((emailAuth && !formData.email) || formData.email !== watch('email')) {
+      setEmailAuth(false);
+    }
+  }, [watch('email')]);
+
   return (
     <div className={S.SignUpContainer}>
       <div className={S.LogoContainer}>

--- a/src/pageContainer/SignUpPage/stepOne/index.tsx
+++ b/src/pageContainer/SignUpPage/stepOne/index.tsx
@@ -16,13 +16,13 @@ type FormValues = {
   email: string;
   password: string;
   repassword?: string;
-  authCode?: number;
+  authCode?: string;
 };
 
 type FormName = 'email' | 'password' | 'repassword';
 
 type SignUpOnePageProps = {
-  formData: { email: string; password: string; authCode: number };
+  formData: { email: string; password: string; authCode: string };
   setFormData: (data: any) => void;
   onNext: () => void;
   authIsOpen: boolean;
@@ -92,7 +92,7 @@ const SignUpOnePage = ({
       email: formData.email || '',
       password: formData.password || '',
       repassword: formData.password || '',
-      authCode: formData.authCode || 0,
+      authCode: formData.authCode || '',
     },
   });
 

--- a/src/pageContainer/SignUpPage/stepTwo/index.tsx
+++ b/src/pageContainer/SignUpPage/stepTwo/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AxiosError } from 'axios';
+import type { AxiosResponse } from 'axios';
 import { useRouter } from 'next/navigation';
 
 import { ImiLogo } from '@/asset';
@@ -52,7 +53,7 @@ const SignUpTwoPage = ({ formData, onPrev }: SignUpTwoPageProps) => {
         email: Data.email,
         password: Data.password,
       });
-      return response.data;
+      return response as unknown as LoginResponse;
     },
   });
 


### PR DESCRIPTION
## 개요 💡

이메일 인증 관련한 로직을 수정했습니다

## 작업내용 ⌨️

1. 이메일 인증을 진행한 후에 이메일을 변경하면 인증을 다시하도록 변경
2. 로그인 & 회원가입에서 사용하는 api요청 react-query로 변경
3. 비밀번호 변경 성공했을대 redirect 주소 변경
4. authcode의 타입을 number에서 string으로 수정 & 기본값을 0 에서 '' 로 수정