### PR TITLE
[fix] content textarea 높이 개선

### DIFF
--- a/src/pageContainer/WritePage/index.tsx
+++ b/src/pageContainer/WritePage/index.tsx
@@ -7,7 +7,7 @@ import { useMyProfile } from '@/hooks';
 import { put } from '@/libs';
 
 import { useMutation } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'react-toastify';
 
 import * as S from './write.css';
@@ -22,6 +22,8 @@ const WritePage = () => {
   const [content, setContent] = useState('');
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+
   const toggleClub = (club: string) => {
     setSelectedClubs((prev) =>
       prev.includes(club) ? prev.filter((c) => c !== club) : [...prev, club]
@@ -29,8 +31,7 @@ const WritePage = () => {
     setHasUnsavedChanges(true);
   };
 
-  const handleResizeHeight = (e: React.FormEvent<HTMLTextAreaElement>) => {
-    const target = e.target as HTMLTextAreaElement;
+  const handleResizeHeight = (target: HTMLTextAreaElement) => {
     target.style.height = 'auto';
     target.style.height = `${target.scrollHeight + 1.8}px`;
   };
@@ -58,6 +59,12 @@ const WritePage = () => {
       setHasUnsavedChanges(false);
     }
   }, [myProfile]);
+
+  useEffect(() => {
+    if (contentRef.current && content) {
+      handleResizeHeight(contentRef.current);
+    }
+  }, [content]);
 
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -176,16 +183,17 @@ const WritePage = () => {
             </p>
           </div>
           <textarea
+            ref={contentRef}
             value={content}
             onChange={(e) => {
               const newContent = e.target.value;
               if (newContent.length <= MAX_CONTENT_LENGTH) {
                 setContent(newContent);
                 setHasUnsavedChanges(true);
+                handleResizeHeight(e.target);
               } else {
                 toast.warn('2400자를 초과했습니다.');
               }
-              handleResizeHeight(e);
             }}
             placeholder="나의 장단점, 각오, 현재하고 있는 공부 등을 자유롭게 작성해보세요."
             className={S.TextareaField}


### PR DESCRIPTION
## 개요 💡

> 기존에는 `수정하기` 버튼을 통해 Write 페이지에 진입할 경우, `content`가 이미 있을 때도 textarea 높이가 최소 높이(lineHeight: 2rem)로 표시되는 문제가 있었습니다.
이번 개선에서는 `content` 초기값이 있는 경우에도 글자 수에 맞게 `textarea` 높이가 자동으로 조정되도록 수정했습니다.

## 화면
### 수정 전
<img width="836" height="614" alt="image" src="https://github.com/user-attachments/assets/517335fa-e0c9-4d96-8d2a-539d6fac5a9d" />

### 수정 후
<img width="865" height="707" alt="image" src="https://github.com/user-attachments/assets/2563b0a2-fd34-4593-97b7-c603a6c6eaec" />
