### PR TITLE
[style] 잘못된 ProfileDetailPage 스타일을 수정

### DIFF
--- a/src/pageContainer/ProfilePages/ProfileDetailPage/index.tsx
+++ b/src/pageContainer/ProfilePages/ProfileDetailPage/index.tsx
@@ -90,7 +90,7 @@ export default function ProfileDetailPage() {
 
         <div className={T.TextContainer}>
           <p className={T.Tag}>동아리</p>
-          <p className={T.Content}>
+          <p className={S.Content}>
             {Array.isArray(profile.wanted)
               ? profile.wanted.join(', ')
               : profile.wanted}

--- a/src/pageContainer/ProfilePages/ProfileDetailPage/profileDetail.css.ts
+++ b/src/pageContainer/ProfilePages/ProfileDetailPage/profileDetail.css.ts
@@ -76,7 +76,6 @@ export const ContentContainer = style({
 export const Content = style({
   fontSize: '1.25rem',
   fontWeight: '300',
-  lineHeight: '2rem',
   wordBreak: 'break-word',
   overflowWrap: 'break-word',
   whiteSpace: 'pre-wrap',


### PR DESCRIPTION
## 개요 💡

> 잘못된 ProfileDetailPage의 스타일을 수정했습니다.

## 화면
[변경 전]
<img width="232" height="102" alt="image" src="https://github.com/user-attachments/assets/07b555ba-6907-492c-b60d-ab2b39c80496" />
[변경 후]
<img width="240" height="96" alt="image" src="https://github.com/user-attachments/assets/8cb679b5-3a95-479d-8e46-93dfac95178d" />